### PR TITLE
修复构建逻辑

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ tmp/**/*
 sds-front/package-lock.json
 
 .DS_Store
+node_modules

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <profile>
             <id>front</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <modules>
                 <module>sds-front</module>

--- a/sds-extension/sds-spring-boot/pom.xml
+++ b/sds-extension/sds-spring-boot/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>sds-extends</artifactId>
+        <artifactId>sds-extension</artifactId>
         <groupId>com.didiglobal.sds</groupId>
         <version>1.0.1-SNAPSHOT</version>
     </parent>

--- a/sds-web/pom.xml
+++ b/sds-web/pom.xml
@@ -112,7 +112,7 @@
         <profile>
             <id>front</id>
             <activation>
-                <activeByDefault>true</activeByDefault>
+                <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
                 <!-- 前端构建件输出地址 -->


### PR DESCRIPTION
- 默认禁用前端构建(可以通过`-Pfont`参数启用profile进行构建)
- 修复构建parent声明错误
- gitignore忽略前端构建依赖